### PR TITLE
IFA3 Compatibility

### DIFF
--- a/AGM_Comp_IFA3/config.cpp
+++ b/AGM_Comp_IFA3/config.cpp
@@ -1,0 +1,49 @@
+class CfgPatches {
+  class AGM_Comp_IFA3 {
+    units[] = {};
+    weapons[] = {};
+    requiredVersion = 0.1;
+    requiredAddons[] = {AiA_BaseConfig_F, AiA_Weapons_IF, LIB_Weapons_A3};
+    version = "1.0";
+    versionStr = "1.0";
+    versionAr[] = {1,0,0};
+    author[] = {"Fadi"};
+  };
+};
+
+class cfgWeapons {
+
+  class LIB_LMG;
+
+  class LIB_MG42: LIB_LMG {
+    AGM_Bipod = 1;
+    AGM_Overheating_allowSwapBarrel = 1;
+  };
+
+  class LIB_MLMG42: LIB_MLMG {
+    // CSW variant (trench) so no bipod.
+    AGM_Bipod = 0;
+    AGM_Overheating_allowSwapBarrel = 1;
+  };
+
+  class LIB_MG42_Tripod: LIB_MLMG42 {};
+
+  class LIB_MG42_veh: LIB_MG42_Tripod {
+    AGM_Bipod = 0;
+    AGM_Overheating_allowSwapBarrel = 0;
+  };
+
+  class Launcher;
+  class LIB_PzFaust_30m: Launcher {
+    AGM_Backblast_Angle = 60;
+    AGM_Backblast_Range = 15;
+    AGM_Backblast_Damage = 0.7;
+  }
+};
+
+class cfgVehicles {
+  class LIB_tank_base: Tank
+  {
+    AGM_FCSEnabled = 0;
+  };
+};

--- a/AGM_Comp_IFA3/config.cpp
+++ b/AGM_Comp_IFA3/config.cpp
@@ -173,7 +173,7 @@ class cfgWeapons {
     descriptionShort = "$STR_AGM_Disposable_UsedTubeDescription";
     magazines[] = {"AGM_UsedTube_F"};
     weaponPoolAvailable = 0;
-  }:
+  };
 
   class LIB_RPzB : Launcher {
     AGM_Backblast_Angle = 60;

--- a/AGM_Comp_IFA3/config.cpp
+++ b/AGM_Comp_IFA3/config.cpp
@@ -125,7 +125,7 @@ class cfgWeapons {
     AGM_Overheating_allowSwapBarrel = 1;
     AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
     AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
-    AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02}
+    AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
   };
 
   // CSW variant

--- a/AGM_Comp_IFA3/config.cpp
+++ b/AGM_Comp_IFA3/config.cpp
@@ -305,4 +305,10 @@ class cfgVehicles {
   class LIB_GER_pilot : LIB_GER_soldier_base {
   	AGM_GForceCoef = 0.75;
   };
+
+  class LIB_US_Soldier_Base;
+  class LIB_US_pilot: LIB_US_Soldier_Base {
+    AGM_GForceCoef = 0.75;
+  }
+
 };

--- a/AGM_Comp_IFA3/config.cpp
+++ b/AGM_Comp_IFA3/config.cpp
@@ -3,12 +3,15 @@ class CfgPatches {
     units[] = {};
     weapons[] = {};
     requiredVersion = 0.1;
-    requiredAddons[] = {AiA_BaseConfig_F, AiA_Weapons_IF, LIB_Weapons_A3};
+    requiredAddons[] = {AGM_Core, AiA_BaseConfig_F, AiA_Weapons_IF, LIB_Weapons_A3};
     version = "1.0";
     versionStr = "1.0";
     versionAr[] = {1,0,0};
     author[] = {"Fadi"};
   };
+};
+
+class CfgAmmo {
 };
 
 class cfgWeapons {
@@ -31,57 +34,64 @@ class cfgWeapons {
   class LIB_LMG;
   class LIB_MLMG;
 
-  class LIB_MP40: LIB_SMG {
+/*
+  class LIB_P38 : LIB_PISTOL {
+  class LIB_M1908 : LIB_P38 {
+  class LIB_TT33 : LIB_M1908 {
+  class LIB_M1895 : LIB_M1908 {
+  class LIB_FLARE_PISTOL : LIB_PISTOL {
+  class LIB_Colt_M1911: LIB_P38 {
+*/
+
+  class LIB_MP40 : LIB_SMG {
     AGM_Overheating_Dispersion[] = {0, 0.001, 0.002, 0.004};
     AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
     AGM_Overheating_JamChance[] = {0, 0, 0.006, 0.02};
   };
 
-  class LIB_K98: LIB_RIFLE {
+  class LIB_K98 : LIB_RIFLE {
     AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
     AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
     AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
   };
 
-  class LIB_K98ZF39: LIB_K98 {
+  class LIB_K98ZF39 : LIB_K98 {
     AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
     AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
     AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
   };
 
-  class LIB_MP44: Rifle {
+  class LIB_MP44 : Rifle {
     AGM_Overheating_Dispersion[] = {0, 0.001, 0.002, 0.004};
     AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
     AGM_Overheating_JamChance[] = {0, 0, 0.006, 0.02};
   };
 
-  class LIB_M9130: LIB_K98
-  {
+  class LIB_M9130 : LIB_K98 {
     AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
     AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
     AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
   };
 
-  class LIB_SVT_40: LIB_M9130
-  {
+  class LIB_SVT_40 : LIB_M9130 {
     AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
     AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
     AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
   };
 
-  class LIB_G43: LIB_SVT_40 {
+  class LIB_G43 : LIB_SVT_40 {
     AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
     AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
     AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
   };
 
-  class LIB_MG42: LIB_LMG {
+  class LIB_MG42 : LIB_LMG {
     AGM_Bipod = 1;
     AGM_Overheating_allowSwapBarrel = 1;
   };
 
   // CSW variant
-  class LIB_MLMG42: LIB_MLMG {
+  class LIB_MLMG42 : LIB_MLMG {
     AGM_Bipod = 0;
     AGM_Overheating_allowSwapBarrel = 1;
     AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
@@ -89,29 +99,27 @@ class cfgWeapons {
     AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
   };
 
-  class LIB_MG42_Tripod: LIB_MLMG42 {};
+  class LIB_MG42_Tripod : LIB_MLMG42 {};
 
-  class LIB_MG42_veh: LIB_MG42_Tripod {
+  class LIB_MG42_veh : LIB_MG42_Tripod {
     AGM_Bipod = 0;
     AGM_Overheating_allowSwapBarrel = 0;
   };
 
-  class LIB_PPSh41_m: LIB_SMG
-  {
+  class LIB_PPSh41_m : LIB_SMG {
     AGM_Overheating_Dispersion[] = {0, 0.001, 0.002, 0.004};
     AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
     AGM_Overheating_JamChance[] = {0, 0, 0.006, 0.02};
   };
-  class LIB_PPSh41_d: LIB_PPSh41_m {};
+  class LIB_PPSh41_d : LIB_PPSh41_m {};
 
-  class LIB_M9130PU: LIB_K98ZF39
-  {
+  class LIB_M9130PU : LIB_K98ZF39 {
     AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
     AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
     AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
   };
 
-  class LIB_DP28: LIB_LMG {
+  class LIB_DP28 : LIB_LMG {
     AGM_Bipod = 1;
     AGM_Overheating_allowSwapBarrel = 0;
     AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
@@ -119,7 +127,7 @@ class cfgWeapons {
     AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
   };
 
-  class LIB_DT: LIB_LMG {
+  class LIB_DT : LIB_LMG {
     AGM_Bipod = 1;
     AGM_Overheating_allowSwapBarrel = 0;
     AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
@@ -127,70 +135,110 @@ class cfgWeapons {
     AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
   };
 
-  class LIB_PzFaust_30m: Launcher {
+  class LIB_M1_Garand: LIB_RIFLE {
+    AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
+    AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+    AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
+  };
+  class LIB_M1_Carbine: LIB_M1_Garand {
+    AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
+    AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+    AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
+  };
+  class LIB_M1903A4_Springfield: LIB_RIFLE {
+    AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
+    AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+    AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
+  };
+  class LIB_M1A1_Thompson: LIB_SMG {
+    AGM_Overheating_Dispersion[] = {0, 0.001, 0.002, 0.004};
+    AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+    AGM_Overheating_JamChance[] = {0, 0, 0.006, 0.02};
+  };
+  class LIB_M1918A2_BAR: Rifle {
+    AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
+    AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+    AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
+  };
+
+  class LIB_PzFaust_30m : Launcher {
+    AGM_Backblast_Angle = 60;
+    AGM_Backblast_Range = 15;
+    AGM_Backblast_Damage = 0.7;
+    AGM_UsedTube = "LIB_PzFaust_30m_used";
+  };
+
+  class LIB_PzFaust_30m_used : LIB_PzFaust_30m {
+    displayName = "$STR_AGM_Disposable_UsedTube";
+    descriptionShort = "$STR_AGM_Disposable_UsedTubeDescription";
+    magazines[] = {"AGM_UsedTube_F"};
+    weaponPoolAvailable = 0;
+  }:
+
+  class LIB_RPzB : Launcher {
     AGM_Backblast_Angle = 60;
     AGM_Backblast_Range = 15;
     AGM_Backblast_Damage = 0.7;
   };
 
+  class LIB_M1A1_Bazooka: Launcher {
+    AGM_Backblast_Angle = 60;
+    AGM_Backblast_Range = 15;
+    AGM_Backblast_Damage = 0.7;
+};
+
+
   // PzKpfw VI Ausf.B + PzKpfw VI Ausf.E
-  class LIB_KwK36_L56: CannonCore
-  {
+  class LIB_KwK36_L56 : CannonCore {
     AGM_DangerZone_Angle = 90;
     AGM_DangerZone_Range = 50;
     AGM_DangerZone_Damage = 0.85;
   };
 
   // PzKpfw VI Ausf.H
-  class LIB_KwK40_L48: CannonCore {
+  class LIB_KwK40_L48 : CannonCore {
     AGM_DangerZone_Angle = 90;
     AGM_DangerZone_Range = 50;
     AGM_DangerZone_Damage = 0.85;
   };
 
   // PzKpfw V Ausf.A Panther
-  class LIB_KwK42_L70: CannonCore
-  {
+  class LIB_KwK42_L70 : CannonCore {
     AGM_DangerZone_Angle = 90;
     AGM_DangerZone_Range = 50;
     AGM_DangerZone_Damage = 0.85;
   };
 
   // StuG III Ausf.g
-  class LIB_StuK40_L48: LIB_KwK40_L48
-  {
+  class LIB_StuK40_L48 : LIB_KwK40_L48 {
     AGM_DangerZone_Angle = 90;
     AGM_DangerZone_Range = 50;
     AGM_DangerZone_Damage = 0.85;
   };
 
   // IS-2
-  class LIB_D25T: CannonCore
-  {
+  class LIB_D25T : CannonCore {
     AGM_DangerZone_Angle = 90;
     AGM_DangerZone_Range = 50;
     AGM_DangerZone_Damage = 0.85;
   };
 
   // T-34-85
-  class LIB_ZIS_S_53: CannonCore
-  {
+  class LIB_ZIS_S_53 : CannonCore {
     AGM_DangerZone_Angle = 90;
     AGM_DangerZone_Range = 50;
     AGM_DangerZone_Damage = 0.85;
   };
 
   // T-34-76
-  class LIB_F34: CannonCore
-  {
+  class LIB_F34 : CannonCore {
     AGM_DangerZone_Angle = 90;
     AGM_DangerZone_Range = 50;
     AGM_DangerZone_Damage = 0.85;
   };
 
   // SU-85
-  class LIB_D_5S: LIB_ZIS_S_53
-  {
+  class LIB_D_5S : LIB_ZIS_S_53 {
     AGM_DangerZone_Angle = 90;
     AGM_DangerZone_Range = 50;
     AGM_DangerZone_Damage = 0.85;
@@ -199,17 +247,17 @@ class cfgWeapons {
 
 class cfgVehicles {
   class Tank;
-  class LIB_tank_base: Tank {
+  class LIB_tank_base : Tank {
     AGM_FCSEnabled = 0;
   };
 
   class LIB_SOV_soldier_base;
-  class LIB_SOV_pilot: LIB_SOV_soldier_base {
-  	AGM_GForceCoef = 0.75; // Should this be lower? Pilots having no G-suit and such...
+  class LIB_SOV_pilot : LIB_SOV_soldier_base {
+  	AGM_GForceCoef = 0.75;
   };
 
   class LIB_GER_soldier_base;
-  class LIB_GER_pilot: LIB_GER_soldier_base {
-  	AGM_GForceCoef = 0.75; // Should this be lower? Pilots having no G-suit and such...
+  class LIB_GER_pilot : LIB_GER_soldier_base {
+  	AGM_GForceCoef = 0.75;
   };
 };

--- a/AGM_Comp_IFA3/config.cpp
+++ b/AGM_Comp_IFA3/config.cpp
@@ -123,6 +123,9 @@ class cfgWeapons {
   class LIB_MG42 : LIB_LMG {
     AGM_Bipod = 1;
     AGM_Overheating_allowSwapBarrel = 1;
+    AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
+    AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+    AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02}
   };
 
   // CSW variant

--- a/AGM_Comp_IFA3/config.cpp
+++ b/AGM_Comp_IFA3/config.cpp
@@ -21,7 +21,7 @@ class cfgWeapons {
   };
 
   class LIB_MLMG42: LIB_MLMG {
-    // CSW variant (trench) so no bipod.
+    // CSW variant
     AGM_Bipod = 0;
     AGM_Overheating_allowSwapBarrel = 1;
   };
@@ -33,17 +33,35 @@ class cfgWeapons {
     AGM_Overheating_allowSwapBarrel = 0;
   };
 
+  class LIB_DP28: LIB_LMG {
+    AGM_Bipod = 1;
+    AGM_Overheating_allowSwapBarrel = 0;
+  };
+
+  class LIB_DT: LIB_LMG {
+    AGM_Bipod = 1;
+    AGM_Overheating_allowSwapBarrel = 0;
+  };
+
   class Launcher;
   class LIB_PzFaust_30m: Launcher {
     AGM_Backblast_Angle = 60;
     AGM_Backblast_Range = 15;
     AGM_Backblast_Damage = 0.7;
-  }
+  };
 };
 
 class cfgVehicles {
   class LIB_tank_base: Tank
   {
     AGM_FCSEnabled = 0;
+  };
+
+  class LIB_SOV_pilot: LIB_SOV_soldier_base {
+  	AGM_GForceCoef = 0.75; // Should this be lower? Pilots having no G-suit and such...
+  };
+
+  class LIB_GER_pilot: LIB_GER_soldier_base {
+  	AGM_GForceCoef = 0.75; // Should this be lower? Pilots having no G-suit and such...
   };
 };

--- a/AGM_Comp_IFA3/config.cpp
+++ b/AGM_Comp_IFA3/config.cpp
@@ -20,8 +20,8 @@ class cfgWeapons {
     AGM_Overheating_allowSwapBarrel = 1;
   };
 
+  // CSW variant
   class LIB_MLMG42: LIB_MLMG {
-    // CSW variant
     AGM_Bipod = 0;
     AGM_Overheating_allowSwapBarrel = 1;
   };
@@ -48,6 +48,69 @@ class cfgWeapons {
     AGM_Backblast_Angle = 60;
     AGM_Backblast_Range = 15;
     AGM_Backblast_Damage = 0.7;
+  };
+
+  // IS-2
+  class LIB_D25T: CannonCore
+  {
+    AGM_DangerZone_Angle = 90;
+    AGM_DangerZone_Range = 50;
+    AGM_DangerZone_Damage = 0.85;
+  };
+
+  // T-34-85
+  class LIB_ZIS_S_53: CannonCore
+  {
+    AGM_DangerZone_Angle = 90;
+    AGM_DangerZone_Range = 50;
+    AGM_DangerZone_Damage = 0.85;
+  };
+
+  // T-34-76
+  class LIB_F34: CannonCore
+  {
+    AGM_DangerZone_Angle = 90;
+    AGM_DangerZone_Range = 50;
+    AGM_DangerZone_Damage = 0.85;
+  };
+
+  // SU-85
+  class LIB_D_5S: LIB_ZIS_S_53
+  {
+    AGM_DangerZone_Angle = 90;
+    AGM_DangerZone_Range = 50;
+    AGM_DangerZone_Damage = 0.85;
+  };
+
+  // PzKpfw VI Ausf.B + PzKpfw VI Ausf.E
+  class LIB_KwK36_L56: CannonCore
+  {
+    AGM_DangerZone_Angle = 90;
+    AGM_DangerZone_Range = 50;
+    AGM_DangerZone_Damage = 0.85;
+  };
+
+  // PzKpfw VI Ausf.H
+  class LIB_KwK40_L48: CannonCore {
+    AGM_DangerZone_Angle = 90;
+    AGM_DangerZone_Range = 50;
+    AGM_DangerZone_Damage = 0.85;
+  };
+
+  // PzKpfw V Ausf.A Panther
+  class LIB_KwK42_L70: CannonCore
+  {
+    AGM_DangerZone_Angle = 90;
+    AGM_DangerZone_Range = 50;
+    AGM_DangerZone_Damage = 0.85;
+  };
+
+  // StuG III Ausf.g
+  class LIB_StuK40_L48: LIB_KwK40_L48
+  {
+    AGM_DangerZone_Angle = 90;
+    AGM_DangerZone_Range = 50;
+    AGM_DangerZone_Damage = 0.85;
   };
 };
 

--- a/AGM_Comp_IFA3/config.cpp
+++ b/AGM_Comp_IFA3/config.cpp
@@ -12,8 +12,68 @@ class CfgPatches {
 };
 
 class cfgWeapons {
+  class Default;
+  class PistolCore;
+  class RifleCore;
+  class MGunCore;
+  class LauncherCore;
+  class CannonCore;
+  class MGun;
+  class GrenadeLauncher;
+  class Rifle;
+  class Launcher;
+  class RocketPods;
+  class HandGunBase;
 
+  class LIB_PISTOL;
+  class LIB_SMG;
+  class LIB_RIFLE;
   class LIB_LMG;
+  class LIB_MLMG;
+
+  class LIB_MP40: LIB_SMG {
+    AGM_Overheating_Dispersion[] = {0, 0.001, 0.002, 0.004};
+    AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+    AGM_Overheating_JamChance[] = {0, 0, 0.006, 0.02};
+  };
+
+  class LIB_K98: LIB_RIFLE {
+    AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
+    AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+    AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
+  };
+
+  class LIB_K98ZF39: LIB_K98 {
+    AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
+    AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+    AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
+  };
+
+  class LIB_MP44: Rifle {
+    AGM_Overheating_Dispersion[] = {0, 0.001, 0.002, 0.004};
+    AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+    AGM_Overheating_JamChance[] = {0, 0, 0.006, 0.02};
+  };
+
+  class LIB_M9130: LIB_K98
+  {
+    AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
+    AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+    AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
+  };
+
+  class LIB_SVT_40: LIB_M9130
+  {
+    AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
+    AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+    AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
+  };
+
+  class LIB_G43: LIB_SVT_40 {
+    AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
+    AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+    AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
+  };
 
   class LIB_MG42: LIB_LMG {
     AGM_Bipod = 1;
@@ -24,6 +84,9 @@ class cfgWeapons {
   class LIB_MLMG42: LIB_MLMG {
     AGM_Bipod = 0;
     AGM_Overheating_allowSwapBarrel = 1;
+    AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
+    AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+    AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
   };
 
   class LIB_MG42_Tripod: LIB_MLMG42 {};
@@ -33,21 +96,72 @@ class cfgWeapons {
     AGM_Overheating_allowSwapBarrel = 0;
   };
 
+  class LIB_PPSh41_m: LIB_SMG
+  {
+    AGM_Overheating_Dispersion[] = {0, 0.001, 0.002, 0.004};
+    AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+    AGM_Overheating_JamChance[] = {0, 0, 0.006, 0.02};
+  };
+  class LIB_PPSh41_d: LIB_PPSh41_m {};
+
+  class LIB_M9130PU: LIB_K98ZF39
+  {
+    AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
+    AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+    AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
+  };
+
   class LIB_DP28: LIB_LMG {
     AGM_Bipod = 1;
     AGM_Overheating_allowSwapBarrel = 0;
+    AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
+    AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+    AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
   };
 
   class LIB_DT: LIB_LMG {
     AGM_Bipod = 1;
     AGM_Overheating_allowSwapBarrel = 0;
+    AGM_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
+    AGM_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+    AGM_Overheating_JamChance[] = {0, 0, 0.004, 0.02};
   };
 
-  class Launcher;
   class LIB_PzFaust_30m: Launcher {
     AGM_Backblast_Angle = 60;
     AGM_Backblast_Range = 15;
     AGM_Backblast_Damage = 0.7;
+  };
+
+  // PzKpfw VI Ausf.B + PzKpfw VI Ausf.E
+  class LIB_KwK36_L56: CannonCore
+  {
+    AGM_DangerZone_Angle = 90;
+    AGM_DangerZone_Range = 50;
+    AGM_DangerZone_Damage = 0.85;
+  };
+
+  // PzKpfw VI Ausf.H
+  class LIB_KwK40_L48: CannonCore {
+    AGM_DangerZone_Angle = 90;
+    AGM_DangerZone_Range = 50;
+    AGM_DangerZone_Damage = 0.85;
+  };
+
+  // PzKpfw V Ausf.A Panther
+  class LIB_KwK42_L70: CannonCore
+  {
+    AGM_DangerZone_Angle = 90;
+    AGM_DangerZone_Range = 50;
+    AGM_DangerZone_Damage = 0.85;
+  };
+
+  // StuG III Ausf.g
+  class LIB_StuK40_L48: LIB_KwK40_L48
+  {
+    AGM_DangerZone_Angle = 90;
+    AGM_DangerZone_Range = 50;
+    AGM_DangerZone_Damage = 0.85;
   };
 
   // IS-2
@@ -81,49 +195,20 @@ class cfgWeapons {
     AGM_DangerZone_Range = 50;
     AGM_DangerZone_Damage = 0.85;
   };
-
-  // PzKpfw VI Ausf.B + PzKpfw VI Ausf.E
-  class LIB_KwK36_L56: CannonCore
-  {
-    AGM_DangerZone_Angle = 90;
-    AGM_DangerZone_Range = 50;
-    AGM_DangerZone_Damage = 0.85;
-  };
-
-  // PzKpfw VI Ausf.H
-  class LIB_KwK40_L48: CannonCore {
-    AGM_DangerZone_Angle = 90;
-    AGM_DangerZone_Range = 50;
-    AGM_DangerZone_Damage = 0.85;
-  };
-
-  // PzKpfw V Ausf.A Panther
-  class LIB_KwK42_L70: CannonCore
-  {
-    AGM_DangerZone_Angle = 90;
-    AGM_DangerZone_Range = 50;
-    AGM_DangerZone_Damage = 0.85;
-  };
-
-  // StuG III Ausf.g
-  class LIB_StuK40_L48: LIB_KwK40_L48
-  {
-    AGM_DangerZone_Angle = 90;
-    AGM_DangerZone_Range = 50;
-    AGM_DangerZone_Damage = 0.85;
-  };
 };
 
 class cfgVehicles {
-  class LIB_tank_base: Tank
-  {
+  class Tank;
+  class LIB_tank_base: Tank {
     AGM_FCSEnabled = 0;
   };
 
+  class LIB_SOV_soldier_base;
   class LIB_SOV_pilot: LIB_SOV_soldier_base {
   	AGM_GForceCoef = 0.75; // Should this be lower? Pilots having no G-suit and such...
   };
 
+  class LIB_GER_soldier_base;
   class LIB_GER_pilot: LIB_GER_soldier_base {
   	AGM_GForceCoef = 0.75; // Should this be lower? Pilots having no G-suit and such...
   };

--- a/AGM_Comp_IFA3/config.cpp
+++ b/AGM_Comp_IFA3/config.cpp
@@ -11,7 +11,42 @@ class CfgPatches {
   };
 };
 
-class CfgAmmo {
+class cfgAmmo {
+  class BulletBase;
+
+  class B_9x18_Ball: BulletBase{};
+
+  class LIB_B_9x19_Ball: B_9x18_Ball {
+//    AGM_BulletMass = ; // 9×19mm Parabellum
+  };
+
+  class B_792x57_Ball: BulletBase {
+//    AGM_BulletMass = ; // 7.92×57mm
+  };
+
+  class B_792x33_Ball: BulletBase {
+//    AGM_BulletMass = ; // 7.92×33mm Kurz
+  };
+
+  class B_762x25_Ball: BulletBase {
+//    AGM_BulletMass = ; // 7.62×25mm Tokarev
+  };
+
+  class LIB_B_762x54_Ball: BulletBase {
+//    AGM_BulletMass = ; // 7.62x54R
+  };
+
+  class B_762x63_Ball: BulletBase {
+//    AGM_BulletMass = ; // .30-06 Springfield AKA 7.62x63
+  };
+
+  class B_762x33_Ball: B_762x63_Ball {
+//    AGM_BulletMass = ; // .30 Carbine AKA 7.62x33
+  };
+
+  class B_127x99_Ball: BulletBase {
+//    AGM_BulletMass = ; // .50 BMG AKA 12.7×99mm NATO
+  };
 };
 
 class cfgWeapons {
@@ -239,6 +274,13 @@ class cfgWeapons {
 
   // SU-85
   class LIB_D_5S : LIB_ZIS_S_53 {
+    AGM_DangerZone_Angle = 90;
+    AGM_DangerZone_Range = 50;
+    AGM_DangerZone_Damage = 0.85;
+  };
+
+  // M4A3(75)
+  class LIB_M3_L40: CannonCore {
     AGM_DangerZone_Angle = 90;
     AGM_DangerZone_Range = 50;
     AGM_DangerZone_Damage = 0.85;


### PR DESCRIPTION
What's been done:

- [x] AGM_GForceCoef for German, Russian and American pilots.

- [x] Bipod support for weapons with a bipod.

- [x] Barrel swapping for weapons that can swap a barrel.

- [x] Disabled AGM FCS for armor. IF/IFA3 has it's own manual FCS for vehicles.

- [x] Generic backblast values for AT launchers.

- [x] Generic overheating values for German, Russian and American small arms.

- [x] Generic overpressure values for German, Russian and American tank cannons.

- [x] The Panzerfaust has been made to use the AGM disposable weapon system.


What's not done:

- [ ] AGM_BulletMass for ammo types.

- [ ] Make IF parachutes non-steerable

- [ ] Distribution of spare barrels to units

- [ ] Generic overpressure values for German or Russian howitzers.

- [ ] Scoped weapons in IFA3 are fixed to the weapon model as opposed to an attachment. This may change at a later date, I don't know.

- [ ] Accurate values for overheating, backblast and overpressure.

I mentioned it in the issue [where I was asked if I would contribute what I had](https://github.com/KoffeinFlummi/AGM_Compatibility/issues/2#issuecomment-66181210) but [someone else has done some work for compatibility](http://dev.withsix.com/projects/ironfront-build/repository/revisions/a7fadea9febfc90aeb5e7e75120be53284592f74) as well on the IF tracker on Dev-Heaven.

From the list above, there's still some things left to do. There could be more that needs to get done as well?  I can do the rest of what's listed but it'll be a bit before I get to it. The group I help run has our anniversary coming up which means I have some mission making to get done. It'll be mid January-ish before I can pick this up again.

I'm also not quite sure what to do about explosives. I'm not sure if it was brought over to A3, but IF had it's own explosives system.

I'm also not sure about the distribution of earplugs. American artillerymen for example were given earplugs but infantry weren't.