### PR TITLE
Fixed RHS USF Leupold Mk4 M3 Scope Inheritance

### DIFF
--- a/AGM_Comp_RHS_USF/config.cpp
+++ b/AGM_Comp_RHS_USF/config.cpp
@@ -187,10 +187,10 @@ class CfgWeapons {
 
 
   // Optics
+  class ItemCore;
   class InventoryOpticsItem_Base_F;
 
-  class rhsusf_acc_sniper_base;
-  class rhsusf_acc_LEUPOLDMK4: rhsusf_acc_sniper_base {
+  class rhsusf_acc_sniper_base: ItemCore {
     AGM_ScopeAdjust_Horizontal[] = {-20, 20};
     AGM_ScopeAdjust_Vertical[] = {-30, 30};
     class ItemInfo: InventoryOpticsItem_Base_F {

--- a/AGM_Comp_RHS_USF/config.cpp
+++ b/AGM_Comp_RHS_USF/config.cpp
@@ -187,12 +187,18 @@ class CfgWeapons {
 
 
   // Optics
-  class ItemCore;
   class InventoryOpticsItem_Base_F;
 
-  class rhsusf_acc_sniper_base: ItemCore {
+  // 2 entries due to different inheritance of the scope and optics mode
+  // Scope inheritance in attachment class
+  class rhsusf_acc_sniper_base;
+  class rhsusf_acc_LEUPOLDMK4: rhsusf_acc_sniper_base {
     AGM_ScopeAdjust_Horizontal[] = {-20, 20};
     AGM_ScopeAdjust_Vertical[] = {-30, 30};
+  };
+  // Optics inheritance in attachment's base class
+  class ItemCore;
+  class rhsusf_acc_sniper_base: ItemCore {
     class ItemInfo: InventoryOpticsItem_Base_F {
       class OpticsModes {
         class pso1_scope {


### PR DESCRIPTION
Should fix #12 - might introduce issues if future RHS release scopes will inherit from it, as it will also inherit this property (but nothing else than sniper scopes should inherit from them anyways).