### PR TITLE
Added FastRoping positions to #2 and #3

### DIFF
--- a/AGM_Comp_RHS_AFRF/config.cpp
+++ b/AGM_Comp_RHS_AFRF/config.cpp
@@ -17,6 +17,31 @@ class CfgVehicles {
     AGM_Wheels[] = {"HitLFWheel", "HitRFWheel", "HitLMWheel", "HitRMWheel", "HitLF2Wheel", "HitRF2Wheel"};
     AGM_WheelsLocalized[] = {STR_AGM_Repair_HitLFWheel, STR_AGM_Repair_HitRFWheel, STR_AGM_Repair_HitLMWheel, STR_AGM_Repair_HitRMWheel, STR_AGM_Repair_HitLBWheel, STR_AGM_Repair_HitRBWheel};
   };
+  
+  class Heli_Attack_02_base_F;
+  class Heli_Light_02_base_F;
+  
+  // Mi-24P
+  class RHS_Mi24_base: Heli_Attack_02_base_F {
+    AGM_FastRoping = 1;
+    AGM_FastRoping_Positions[] = {{1.7, 2.9, -0.4}, {-0.5, 2.9, -0.4}};
+  };
+  // Mi-24V, Mi-24VT (inherits)
+  class RHS_Mi24V_Base: RHS_Mi24_base {
+    AGM_FastRoping = 1;
+    AGM_FastRoping_Positions[] = {{1, 2.9, -0.4}, {-1.2, 2.9, -0.4}};
+  };
+  
+  // Mi-8 (Base)
+  class RHS_Mi8_base: Heli_Light_02_base_F {
+    AGM_FastRoping = 0;
+  };
+  
+  // Mi-8MTV-3, Mi-8AMTSh (inherits)
+  class rhs_mi8mtv3_base: RHS_Mi8_base {
+    AGM_FastRoping = 1;
+    AGM_FastRoping_Positions[] = {{-1.25, 5.1, -0.9}};
+  };
 };
 
 class CfgAmmo {

--- a/AGM_Comp_RHS_USF/config.cpp
+++ b/AGM_Comp_RHS_USF/config.cpp
@@ -11,6 +11,23 @@ class CfgPatches {
   };
 };
 
+class CfgVehicles {
+  class Heli_Transport_01_base_F;
+  class Heli_Transport_02_base_F;
+  
+  // UH-60
+  class RHS_UH60_Base: Heli_Transport_01_base_F {
+    AGM_FastRoping = 1;
+    AGM_FastRoping_Positions[] = {{1.45, 1.925, -0.45}};
+  };
+
+  // CH-47F
+  class RHS_CH_47F_base: Heli_Transport_02_base_F {
+    AGM_FastRoping = 1;
+    AGM_FastRoping_Positions[] = {{0,-0.7,-3.2}, {0, -7, -1}};
+  };
+};
+
 class CfgAmmo {
   class BulletBase;
   class B_556x45_Ball;


### PR DESCRIPTION
From comments in both RHS issues:
USF:
>- Pilot and Copilot `driverCanEject` to (others already have it):
 - [ ] ~~CH-47F~~ (defined for every subclass - won't change)
 - [ ] ~~UH-60M~~ (defined for every subclass - won't change)
- Fast-Roping positions (works on all but they are not on correct or good-looking locations)
 - [x] CH-47F = {{0,-0.7,-3.2}, {0, -7, -1}}
 - [x] UH-60 = {{1.45, 1.925, -0.45}} (one hook on right side)

AFRF:
>- Fast-Roping positions (works on all but they are not on correct or good-looking locations)
 - All except Ka-60 (inherits properly from vanilla)
 - [x] Mi-24P = {{1.7, 2.9, -0.4}, {-0.5, 2.9, -0.4}}
 - [x] Mi-24V, Mi-24VT = {{1, 2.9, -0.4}, {-1.1, 2.9, -0.4}}
 - [x] Mi-8AMTSh, Mi-8MTV-3 = {{-1.25, 5.1, -0.9}} (Mi-8AMT and Mi-8MT don't have the hooks)

Luckily the inheritance in RHS is pretty neat and so I didn't have to do anything to separate non-hook Mi-8s and the one that have the hook.