### PR TITLE
CUP Launchers: Disposables

### DIFF
--- a/AGM_Comp_CUP_Weapons_M136/config.cpp
+++ b/AGM_Comp_CUP_Weapons_M136/config.cpp
@@ -1,0 +1,61 @@
+class CfgPatches {
+  class AGM_Comp_CUP_Weapons_M136 {
+    units[] = {};
+    weapons[] = {};
+    requiredVersion = 0.1;
+    requiredAddons[] = {AGM_Comp_CUP_Weapons_Ammunition,CUP_Weapons_Ammunition,CUP_Weapons_M136};
+    version = "1.0";
+    versionStr = "1.0";
+    versionAr[] = {1,0,0};
+    author[] = {"Winter"};
+    authorUrl = "https://github.com/Winter259";
+  };
+};
+
+class CfgWeapons {
+  class Launcher_Base_F;
+  // CUP_Weapons_M136
+  class CUP_launch_M136: Launcher_Base_F {
+    AGM_Backblast_Angle = 45;
+    AGM_Backblast_Range = 100;
+    AGM_Backblast_Damage = 0.7;
+    AGM_UsedTube = "AGM_launch_M136_Used_F"; // The class name of the used tube.
+    magazines[] = {"AGM_PreloadedMissileDummy_CUP"}; // The dummy magazine
+  };
+  class AGM_launch_M136_Used_F: CUP_launch_M136 { // the used tube should be a sub class of the disposable launcher
+    scope = 1;
+    AGM_isUsedLauncher = 1;
+    author = "$STR_AGM_Core_AGMTeam";
+    displayName = "$STR_AGM_Disposable_UsedTube";
+    descriptionShort = "$STR_AGM_Disposable_UsedTubeDescription";
+    magazines[] = {"AGM_FiredMissileDummy_CUP"}; // This will disable the used launcher class from being fired again.
+    //picture = ""; @todo
+    //model = ""; @todo
+    weaponPoolAvailable = 0;
+  };
+};
+
+class CfgMagazines {
+  class CUP_M136_M;
+  class AGM_PreloadedMissileDummy_CUP: CUP_M136_M {              // The dummy magazine
+    author = "$STR_AGM_Core_AGMTeam";
+    scope = 1;
+    displayName = "$STR_AGM_Disposable_PreloadedMissileDummy";
+    picture = "\AGM_Core\UI\blank_CO.paa";
+    weaponPoolAvailable = 0;
+    mass = 0;
+  };
+  class AGM_FiredMissileDummy_CUP: AGM_PreloadedMissileDummy_CUP {
+    count = 0;
+  };
+  class AGM_UsedTube_F: CUP_M136_M {
+    author = "$STR_AGM_Core_AGMTeam";
+    displayName = "$STR_AGM_Disposable_UsedTube";
+    descriptionShort = "$STR_AGM_Disposable_UsedTubeDescription";
+    displayNameShort = "-";
+    count = 0;
+    weaponPoolAvailable = 0;
+    modelSpecial = "";
+    mass = 0;
+  };
+};

--- a/AGM_Comp_CUP_Weapons_M136/config.cpp
+++ b/AGM_Comp_CUP_Weapons_M136/config.cpp
@@ -3,7 +3,7 @@ class CfgPatches {
     units[] = {};
     weapons[] = {};
     requiredVersion = 0.1;
-    requiredAddons[] = {AGM_Comp_CUP_Weapons_Ammunition,CUP_Weapons_Ammunition,CUP_Weapons_M136};
+    requiredAddons[] = {CUP_Weapons_Ammunition,CUP_Weapons_M136};
     version = "1.0";
     versionStr = "1.0";
     versionAr[] = {1,0,0};

--- a/AGM_Comp_CUP_Weapons_NLAW/config.cpp
+++ b/AGM_Comp_CUP_Weapons_NLAW/config.cpp
@@ -1,0 +1,59 @@
+class CfgPatches {
+  class AGM_Comp_CUP_Weapons_NLAW {
+    units[] = {};
+    weapons[] = {};
+    requiredVersion = 0.1;
+    requiredAddons[] = {CUP_Weapons_Ammunition,CUP_Weapons_NLAW};
+    version = "1.0";
+    versionStr = "1.0";
+    versionAr[] = {1,0,0};
+    author[] = {"Winter"};
+    authorUrl = "https://github.com/Winter259";
+  };
+};
+
+class CfgWeapons {
+  class Launcher_Base_F;
+  // CUP_Weapons_NLAW
+  class CUP_launch_NLAW: Launcher_Base_F {
+    AGM_Backblast_Damage = 0; // Soft launch
+    AGM_UsedTube = "AGM_launch_NLAW_Used_F_CUP"; // The class name of the used tube.
+    magazines[] = {"AGM_PreloadedMissileDummy_CUP"}; // The dummy magazine
+  };
+  class AGM_launch_NLAW_Used_F_CUP: CUP_launch_NLAW { // Requires a differently named weapon than that used in the PCML disposable patch
+    scope = 1;
+    AGM_isUsedLauncher = 1;
+    author = "$STR_AGM_Core_AGMTeam";
+    displayName = "$STR_AGM_Disposable_UsedTube";
+    descriptionShort = "$STR_AGM_Disposable_UsedTubeDescription";
+    magazines[] = {"AGM_FiredMissileDummy_CUP"}; // This will disable the used launcher class from being fired again.
+    //picture = ""; @todo
+    //model = ""; @todo
+    weaponPoolAvailable = 0;
+  };
+};
+
+class CfgMagazines {
+  class CUP_NLAW_M;
+  class AGM_PreloadedMissileDummy_CUP: CUP_NLAW_M {              // The dummy magazine
+    author = "$STR_AGM_Core_AGMTeam";
+    scope = 1;
+    displayName = "$STR_AGM_Disposable_PreloadedMissileDummy";
+    picture = "\AGM_Core\UI\blank_CO.paa";
+    weaponPoolAvailable = 0;
+    mass = 0;
+  };
+  class AGM_FiredMissileDummy_CUP: AGM_PreloadedMissileDummy_CUP {
+    count = 0;
+  };
+  class AGM_UsedTube_F: CUP_NLAW_M {
+    author = "$STR_AGM_Core_AGMTeam";
+    displayName = "$STR_AGM_Disposable_UsedTube";
+    descriptionShort = "$STR_AGM_Disposable_UsedTubeDescription";
+    displayNameShort = "-";
+    count = 0;
+    weaponPoolAvailable = 0;
+    modelSpecial = "";
+    mass = 0;
+  };
+};

--- a/AGM_Comp_CUP_Weapons_RPG18/config.cpp
+++ b/AGM_Comp_CUP_Weapons_RPG18/config.cpp
@@ -3,7 +3,7 @@ class CfgPatches {
     units[] = {};
     weapons[] = {};
     requiredVersion = 0.1;
-    requiredAddons[] = {AGM_Comp_CUP_Weapons_Ammunition, CUP_Weapons_Ammunition,CUP_Weapons_RPG18};
+    requiredAddons[] = {CUP_Weapons_Ammunition,CUP_Weapons_RPG18};
     version = "1.0";
     versionStr = "1.0";
     versionAr[] = {1,0,0};

--- a/AGM_Comp_CUP_Weapons_RPG18/config.cpp
+++ b/AGM_Comp_CUP_Weapons_RPG18/config.cpp
@@ -1,0 +1,61 @@
+class CfgPatches {
+  class AGM_Comp_CUP_Weapons_RPG18 {
+    units[] = {};
+    weapons[] = {};
+    requiredVersion = 0.1;
+    requiredAddons[] = {AGM_Comp_CUP_Weapons_Ammunition, CUP_Weapons_Ammunition,CUP_Weapons_RPG18};
+    version = "1.0";
+    versionStr = "1.0";
+    versionAr[] = {1,0,0};
+    author[] = {"Winter"};
+    authorUrl = "https://github.com/Winter259";
+  };
+};
+
+class CfgWeapons {
+  class Launcher_Base_F;
+  // CUP_Weapons_RPG18
+  class CUP_launch_RPG18: Launcher_Base_F {
+    AGM_Backblast_Angle = 40;
+    AGM_Backblast_Range = 15;
+    AGM_Backblast_Damage = 1;
+	AGM_UsedTube = "AGM_launch_RPG18_Used_F"; // The class name of the used tube.
+    magazines[] = {"AGM_PreloadedMissileDummy_CUP"}; // The dummy magazine
+  };
+  class AGM_launch_RPG18_Used_F: CUP_launch_RPG18 { // the used tube should be a sub class of the disposable launcher
+    scope = 1;
+    AGM_isUsedLauncher = 1;
+    author = "$STR_AGM_Core_AGMTeam";
+    displayName = "$STR_AGM_Disposable_UsedTube";
+    descriptionShort = "$STR_AGM_Disposable_UsedTubeDescription";
+    magazines[] = {"AGM_FiredMissileDummy_CUP"}; // This will disable the used launcher class from being fired again.
+    //picture = ""; @todo
+    //model = ""; @todo
+    weaponPoolAvailable = 0;
+  };
+};
+
+class CfgMagazines {
+  class CUP_RPG18_M;
+  class AGM_PreloadedMissileDummy_CUP: CUP_RPG18_M {              // The dummy magazine
+    author = "$STR_AGM_Core_AGMTeam";
+    scope = 1;
+    displayName = "$STR_AGM_Disposable_PreloadedMissileDummy";
+    picture = "\AGM_Core\UI\blank_CO.paa";
+    weaponPoolAvailable = 0;
+    mass = 0;
+  };
+  class AGM_FiredMissileDummy_CUP: AGM_PreloadedMissileDummy_CUP {
+    count = 0;
+  };
+  class AGM_UsedTube_F: CUP_RPG18_M {
+    author = "$STR_AGM_Core_AGMTeam";
+    displayName = "$STR_AGM_Disposable_UsedTube";
+    descriptionShort = "$STR_AGM_Disposable_UsedTubeDescription";
+    displayNameShort = "-";
+    count = 0;
+    weaponPoolAvailable = 0;
+    modelSpecial = "";
+    mass = 0;
+  };
+};

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -12,4 +12,3 @@ Garth "L-H" de Wet <garthofhearts@gmail.com>
 Jo David
 Jonpas <jonpas33@gmail.com>
 Fadi
-Simon "Winter" Agius Muscat <simon@agius-muscat.net>

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -12,3 +12,4 @@ Garth "L-H" de Wet <garthofhearts@gmail.com>
 Jo David
 Jonpas <jonpas33@gmail.com>
 Fadi
+Simon "Winter" Agius Muscat <simon@agius-muscat.net>


### PR DESCRIPTION
Disposables configs for CUP Launchers, tested and working in the editor (Virtual Arsenal breaks AGM disposables, lets you do things like reload them). I made the NLAW soft launch as per it actually being soft launch in real life (https://en.wikipedia.org/wiki/MBT_LAW). Might want to update #5 after merging.